### PR TITLE
Improve SDL rumble handling and gamepad feedback

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -2382,6 +2382,10 @@ function main.f_menuWindow(t)
 end
 
 --Load additional scripts
+local okR, mod = pcall(require, 'external.script.rumble')
+if okR then Rumble = mod end
+pcall(require, 'external.script.rumble_menu_hook')
+pcall(require, 'external.script.rumble_fight_hook')
 start = require('external.script.start')
 randomtest = require('external.script.randomtest')
 options = require('external.script.options')

--- a/external/script/rumble.lua
+++ b/external/script/rumble.lua
@@ -1,49 +1,49 @@
--- rumble.lua
--- Interface Lua --> Go pour gérer les vibrations manette
+-- Hardened rumble wrapper for Go bindings ---------------------
 
--- Petite abstraction pour le moteur
-Rumble = {}
+local M = {}
 
--- Vérifie si le moteur Go expose la fonction (protection au cas où)
-local hasRumble = (RumbleGamepad ~= nil)
+local last = 0
+local cooldown = 150 -- ms
 
--- Vibre fort pour les coups puissants
-function Rumble.heavy()
-    if hasRumble then
-        RumbleGamepad(800) -- Durée en ms
+local function connected()
+    return GamepadIsConnected and GamepadIsConnected()
+end
+
+local function hasRumble()
+    return GamepadHasRumble and GamepadHasRumble()
+end
+
+function M.available()
+    return connected() and hasRumble()
+end
+
+function M.hasRumble()
+    return hasRumble()
+end
+
+function M.controller_name()
+    if GamepadControllerName then
+        return GamepadControllerName() or ""
+    end
+    return ""
+end
+
+local function doRumble(ms)
+    local now = os.clock() * 1000
+    if now - last < cooldown then return end
+    last = now
+    if RumbleGamepad then RumbleGamepad(ms) end
+end
+
+function M.vibrate(ms)
+    if M.available() then
+        doRumble(ms or 500)
     end
 end
 
--- Vibration légère pour les petits coups ou impacts
-function Rumble.light()
-    if hasRumble then
-        RumbleGamepad(300)
-    end
-end
+function M.menuSelect() if M.available() then doRumble(150) end end
+function M.menuBack()   if M.available() then doRumble(200) end end
+function M.light()      if M.available() then doRumble(300) end end
+function M.heavy()      if M.available() then doRumble(800) end end
 
--- Vibration lors d'une sélection dans le menu
-function Rumble.menuSelect()
-    if hasRumble then
-        RumbleGamepad(150)
-    end
-end
-
--- Vibration lors d'un cancel / retour menu
-function Rumble.menuBack()
-    if hasRumble then
-        RumbleGamepad(200)
-    end
-end
-
--- Fonction générique personnalisable
-function Rumble.custom(ms)
-    if hasRumble then
-        RumbleGamepad(ms or 500)
-    end
-end
-
--- Pour usage global : ex.
--- Rumble.light() dans un hitdef
--- Rumble.menuSelect() lors d'un son de bouton pressé
-
-return Rumble
+return M

--- a/external/script/rumble_fight_hook.lua
+++ b/external/script/rumble_fight_hook.lua
@@ -1,0 +1,34 @@
+-- Adds rumble feedback during fights for hits and damage.
+
+if not hook or not hook.add then return end
+
+local lastLife = {}
+
+local function initLife()
+    lastLife = {}
+    for p = 1, 2 do
+        if player(p) then
+            lastLife[p] = life()
+        end
+    end
+end
+
+hook.add('launchFight', 'rumble_init_life', function()
+    initLife()
+end)
+
+hook.add('loop', 'rumble_fight', function()
+    if not Rumble or not Rumble.available or not Rumble.available() then return end
+    for p = 1, 2 do
+        if player(p) then
+            if movehit() and Rumble.light then Rumble.light() end
+            local l = life()
+            if lastLife[p] and l < lastLife[p] and Rumble.heavy then
+                Rumble.heavy()
+            end
+            lastLife[p] = l
+        end
+    end
+end)
+
+return true

--- a/external/script/rumble_menu_hook.lua
+++ b/external/script/rumble_menu_hook.lua
@@ -12,7 +12,7 @@ local last = { up=false, down=false, left=false, right=false, ok=false, back=fal
 
 local function detect_and_rumble(section)
     -- Ensure Rumble is available
-    if not Rumble then return end
+    if not Rumble or not Rumble.available or not Rumble.available() then return end
 
     -- Cancel / Back
     if safe_call(esc) or main.f_input(main.t_players, {'m'}) then

--- a/src/script.go
+++ b/src/script.go
@@ -247,6 +247,18 @@ func systemScriptInit(l *lua.LState) {
 		return 1
 	})
 
+	// Lua: GamepadHasRumble() -> bool
+	luaRegister(l, "GamepadHasRumble", func(l *lua.LState) int {
+		l.Push(lua.LBool(HasRumble()))
+		return 1
+	})
+
+	// Lua: GamepadControllerName() -> string
+	luaRegister(l, "GamepadControllerName", func(l *lua.LState) int {
+		l.Push(lua.LString(ControllerName()))
+		return 1
+	})
+
 	luaRegister(l, "addHotkey", func(*lua.LState) int {
 		l.Push(lua.LBool(func() bool {
 			k := StringToKey(strArg(l, 1))
@@ -1743,19 +1755,20 @@ func systemScriptInit(l *lua.LState) {
 				axes := input.GetJoystickAxes(joy)
 				btns := input.GetJoystickButtons(joy)
 
+				for i := range btns {
+					if btns[i] > 0 {
+						s = strconv.Itoa(i)
+						break
+					}
+				}
+				if s != "" {
+					break
+				}
 				s = CheckAxisForDpad(joy, &axes, len(btns))
 				if s != "" {
 					break
 				}
 				s = CheckAxisForTrigger(joy, &axes)
-				if s != "" {
-					break
-				}
-				for i := range btns {
-					if btns[i] > 0 {
-						s = strconv.Itoa(i)
-					}
-				}
 				if s != "" {
 					break
 				}


### PR DESCRIPTION
## Summary
- improve SDL gamepad init with haptic fallback and rumble capability queries
- expose controller name and rumble availability to Lua and favor D-pad buttons for mapping
- add Lua rumble module with cooldown and hooks for menus and fights

## Testing
- `go build -o ikemen ./src` *(fails: Package 'gl' not found; Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e8145bdc832fa9fe2d16872fc4a4