### PR TITLE
Map PlayStation controllers

### DIFF
--- a/src/sdl_input_stub.go
+++ b/src/sdl_input_stub.go
@@ -7,3 +7,5 @@ func InitGamepad() error       { return nil }
 func CloseGamepad()            {}
 func Rumble(durationMs int)    {}
 func IsGamepadConnected() bool { return false }
+func HasRumble() bool          { return false }
+func ControllerName() string   { return "" }

--- a/src/system.go
+++ b/src/system.go
@@ -30,6 +30,12 @@ const (
 	MaxPlayerNo     = MaxSimul*2 + MaxAttachedChar
 )
 
+const (
+	SDL_CONTROLLER_BUTTON_X             = 2
+	SDL_CONTROLLER_BUTTON_Y             = 3
+	SDL_CONTROLLER_BUTTON_RIGHTSHOULDER = 10
+)
+
 // sys
 // The only instance of a System struct.
 // Do not create more than 1.
@@ -347,6 +353,23 @@ func (s *System) init(w, h int32) *lua.LState {
 					}
 				}
 			}
+		}
+	}
+
+	for i := 0; i < len(sys.joystickConfig); i++ {
+		jc := &sys.joystickConfig[i]
+		name := ControllerName()
+		if name == "" {
+			name = input.GetJoystickName(jc.Joy)
+		}
+		if strings.Contains(name, "DualShock") ||
+			strings.Contains(name, "PS4") ||
+			strings.Contains(name, "PS5") ||
+			strings.Contains(name, "Wireless Controller") ||
+			strings.Contains(name, "DualSense") {
+			jc.kA = SDL_CONTROLLER_BUTTON_X
+			jc.kB = SDL_CONTROLLER_BUTTON_Y
+			jc.kC = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Map PlayStation controllers so Square/Triangle/R1 trigger A/B/C
- Stub controller functions for non-Windows builds

## Testing
- `go build -o /tmp/ikemen ./src` *(fails: missing system libraries)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f318b594832f806752de155cf040