### PR TITLE
Fix classic motif fonts

### DIFF
--- a/data.old/mugenclassic/system.def
+++ b/data.old/mugenclassic/system.def
@@ -41,15 +41,15 @@ intro.storyboard =        ;Intro storyboard definition (optional)
 select = select.def       ;Character and stage selection list
 fight = fight.def         ;Fight definition filename
 ;System fonts
-font1 = f-4x6.def
-font2 = name14.def
-font3 = enter48.def
-font4 = arcade.def
-font5 = mssansserif-tt36.def
+font1 = font/Open_Sans/Open_Sans.def
+font2 = font/default-3x5.def
+font3 = font/default-3x5-bold.def
+font4 = font/debug.def
+font5 = font/Open_Sans/Open_Sans.def
 ;font5.height = 36         ;Uncomment to override the size of the font (Truetype fonts only)
-font6 = infofont.def
-font7 = Open_Sans.def
-font8 = num48.def
+font6 = font/default-3x5.def
+font7 = font/default-3x5-bold.def
+font8 = font/debug.def
 module =                  ;Ikemen feature: External Lua code
 
 ;----------------------------

--- a/font/Open_Sans/Open_Sans.def
+++ b/font/Open_Sans/Open_Sans.def
@@ -1,0 +1,24 @@
+[FNT v2]
+; FNT v2 version number. Don't change this.
+fntversion = 2,00
+; Name of this font.
+name = "Open Sans"
+; Font author
+author = "Steve Matteson"
+
+[Def]
+; This is a truetype font.
+Type = truetype
+; Size of font: width, height. Only height is used for truetype fonts.
+Size = 0,24
+; Spacing between font glyphs. Only height is used for truetype fonts.
+Spacing = 1,4
+; Drawing offset: x, y.
+Offset = 0,0
+; Filename of the font to load. Will search Windows font directory if not in current directory.
+File = OpenSans-Regular.ttf
+; Preferred blending mode: 0 - none, 1 - blended.
+Blend = 1
+
+; Note: All units are in pixels.
+; Text rendered with truetype fonts may be ASCII or UTF-8

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -105,7 +105,7 @@ Ratio.Level4.Life     = 1.4
 ; -------------------------------------------------------------------------------
 [Config]
 ; Motif to use. Motifs are themes that define the look and feel of Ikemen GO.
-Motif                = data/mugenclassic/system.def
+Motif                = data.old/mugenclassic/system.def
 ; Max amount of player-controlled characters (2-8)
 Players             = 4
 ; The rate at which consecutive frames are rendered. The game can refresh


### PR DESCRIPTION
## Summary
- load classic system motif from `data.old/mugenclassic/system.def`
- replace missing classic motif font references with existing fonts
- add Open Sans font definition used by classic motif

## Testing
- `go test ./...` *(fails: undefined: HasRumble)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f9c4aedc832fb3a7df5e15aae60f