### PR TITLE
Return error when updating gamepad mappings fails

### DIFF
--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -26,8 +26,8 @@ func LoadGamepadMappings(path string) error {
 	if err != nil {
 		return err
 	}
-	if err := glfw.UpdateGamepadMappings(string(data)); err != nil {
-		return err
+	if ok := glfw.UpdateGamepadMappings(string(data)); !ok {
+		return fmt.Errorf("failed to update gamepad mappings")
 	}
 	if err := AddSDLGamepadMappingsFromFile(path); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- return a descriptive error if GLFW's UpdateGamepadMappings fails

## Testing
- `go build -tags=windows -o ../ikemen.exe`
- `GOOS=windows GOARCH=amd64 go build -tags=windows -o ../ikemen.exe ./src`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ go build -tags=windows -o ../ikemen.exe ./src`

------
https://chatgpt.com/codex/tasks/task_e_68b98f83fa2c832fa9677a04d13bd5ba