### PR TITLE
feat(input): add SDL2 gamepad backend and Lua rumble API (Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@
 
 ```bash
 git clone https://github.com/YourGitHubUsername/Ikemen-Sense.git
-cd Ikemen-Sense/src
-go build -tags=windows -o ../IkemenSense.exe
+cd Ikemen-Sense
+set CGO_ENABLED=1
+go build -tags "windows sdl" -o IkemenSense.exe ./src
 ```
 
 For detailed steps, check the [original engine wiki](https://github.com/ikemen-engine/Ikemen-GO/wiki).
@@ -65,7 +66,7 @@ following Lua snippet:
 
 ```lua
 if Rumble.available() and Rumble.hasRumble() then
-    Rumble.vibrate(200)
+    Rumble.vibrate(0.5, 200)
 end
 ```
 

--- a/external/script/rumble.lua
+++ b/external/script/rumble.lua
@@ -6,33 +6,33 @@ local M = Rumble or {}
 local last = 0
 local cooldown = 0.12 -- seconds
 
-local function fire(ms)
+local function fire(intensity, ms)
     local now = os.clock()
     if now - last < cooldown then return end
     last = now
     if M and M.vibrate then
-        M.vibrate(ms)
+        M.vibrate(intensity, ms)
     end
 end
 
 --- Light rumble, useful for weak feedback cues.
 function M.light()
-    fire(40)
+    fire(0.3, 40)
 end
 
 --- Menu selection confirmation rumble.
 function M.menuSelect()
-    fire(80)
+    fire(0.5, 80)
 end
 
 --- Menu back/cancel rumble.
 function M.menuBack()
-    fire(100)
+    fire(0.5, 100)
 end
 
 --- Short pulse used for cursor movement.
 function M.move()
-    fire(30)
+    fire(0.4, 30)
 end
 
 return M

--- a/src/script.go
+++ b/src/script.go
@@ -241,40 +241,7 @@ func toLValue(l *lua.LState, v interface{}) lua.LValue {
 func systemScriptInit(l *lua.LState) {
 	triggerFunctions(l)
 	deprecatedFunctions(l)
-	// Rumble table exposes basic controller vibration controls to Lua.
-	// Functions are safe to call even when no gamepad is connected.
-	rumble := l.NewTable()
-	l.SetGlobal("Rumble", rumble)
-
-	// Rumble.vibrate(ms)
-	// Triggers controller vibration for the given duration in milliseconds.
-	l.SetField(rumble, "vibrate", l.NewFunction(func(l *lua.LState) int {
-		if HasRumble() {
-			Rumble(int(numArg(l, 1)))
-		}
-		return 0
-	}))
-
-	// Rumble.available() -> bool
-	// Reports whether a controller is currently connected.
-	l.SetField(rumble, "available", l.NewFunction(func(l *lua.LState) int {
-		l.Push(lua.LBool(IsGamepadConnected()))
-		return 1
-	}))
-
-	// Rumble.hasRumble() -> bool
-	// Indicates if the connected controller supports vibration.
-	l.SetField(rumble, "hasRumble", l.NewFunction(func(l *lua.LState) int {
-		l.Push(lua.LBool(HasRumble()))
-		return 1
-	}))
-
-	// Rumble.controller_name() -> string
-	// Returns the controller name or an empty string.
-	l.SetField(rumble, "controller_name", l.NewFunction(func(l *lua.LState) int {
-		l.Push(lua.LString(ControllerName()))
-		return 1
-	}))
+	registerRumble(l)
 	// addChar(defs string)
 	// Adds one or more character definition paths to the select screen.
 	// Each line of the string parameter is treated as a separate .def file.

--- a/src/script_rumble.go
+++ b/src/script_rumble.go
@@ -1,0 +1,40 @@
+//go:build sdl
+// +build sdl
+
+package main
+
+import lua "github.com/yuin/gopher-lua"
+
+// registerRumble exposes controller vibration helpers to Lua scripts.
+func registerRumble(l *lua.LState) {
+	rumble := l.NewTable()
+	l.SetGlobal("Rumble", rumble)
+
+	// Rumble.vibrate(intensity, ms)
+	l.SetField(rumble, "vibrate", l.NewFunction(func(l *lua.LState) int {
+		intensity := float64(numArg(l, 1))
+		ms := int(numArg(l, 2))
+		if HasRumble() {
+			Rumble(intensity, ms)
+		}
+		return 0
+	}))
+
+	// Rumble.available() -> bool
+	l.SetField(rumble, "available", l.NewFunction(func(l *lua.LState) int {
+		l.Push(lua.LBool(IsGamepadConnected()))
+		return 1
+	}))
+
+	// Rumble.hasRumble() -> bool
+	l.SetField(rumble, "hasRumble", l.NewFunction(func(l *lua.LState) int {
+		l.Push(lua.LBool(HasRumble()))
+		return 1
+	}))
+
+	// Rumble.controller_name() -> string
+	l.SetField(rumble, "controller_name", l.NewFunction(func(l *lua.LState) int {
+		l.Push(lua.LString(ControllerName()))
+		return 1
+	}))
+}

--- a/src/script_rumble_stub.go
+++ b/src/script_rumble_stub.go
@@ -1,0 +1,9 @@
+//go:build !sdl
+// +build !sdl
+
+package main
+
+import lua "github.com/yuin/gopher-lua"
+
+// registerRumble is a no-op when SDL support is disabled.
+func registerRumble(l *lua.LState) {}

--- a/src/sdl_input_stub.go
+++ b/src/sdl_input_stub.go
@@ -1,26 +1,27 @@
-//go:build !windows
+//go:build !sdl
+// +build !sdl
 
 // sdl_input_stub.go provides no-op implementations of the gamepad rumble
-// helpers on non-Windows platforms. The real implementation lives in
-// sdl_input.go and uses SDL2. These stubs allow the rest of the engine to
-// compile on other platforms without conditional checks.
+// helpers when the sdl build tag is not enabled. The real implementation
+// lives in sdl_input.go and uses SDL2. These stubs allow the rest of the
+// engine to compile without conditional checks.
 package main
 
-// InitGamepad performs no initialization on non-Windows builds.
+// InitGamepad performs no initialization when SDL support is disabled.
 // Return value: always nil since no work is done.
 func InitGamepad() error { return nil }
 
-// CloseGamepad is a no-op placeholder for non-Windows builds.
+// CloseGamepad is a no-op placeholder when SDL support is disabled.
 func CloseGamepad() {}
 
-// IsGamepadConnected always reports false outside Windows.
+// IsGamepadConnected always reports false when SDL support is disabled.
 func IsGamepadConnected() bool { return false }
 
-// HasRumble always reports false outside Windows.
+// HasRumble always reports false when SDL support is disabled.
 func HasRumble() bool { return false }
 
-// ControllerName returns an empty string outside Windows.
+// ControllerName returns an empty string when SDL support is disabled.
 func ControllerName() string { return "" }
 
-// Rumble performs no action on non-Windows builds.
-func Rumble(ms int) {}
+// Rumble performs no action when SDL support is disabled.
+func Rumble(intensity float64, ms int) {}


### PR DESCRIPTION
- Windows-only SDL2 input backend (HIDAPI hints, controller name, haptic fallback)
- Lua `Rumble` table (vibrate/available/hasRumble/controller_name)
- Clean init/shutdown of gamepad system
- Optional Lua presets module (debounced)
- Docs updated (bundled SDL2, build steps, usage)

Build:
- Use: `CGO_ENABLED=1 go build -tags "windows sdl" -o IkemenSense.exe ./src`
- Ensure `external/SDL2/include` and `external/SDL2/lib/x64` are present
- Keep GLFW/OpenGL sources included; SDL is for input only

------
https://chatgpt.com/codex/tasks/task_e_68ba248484e4832f8c5aabdd9c0b93cc